### PR TITLE
Add AudioContext.outputLatency checkbox

### DIFF
--- a/audio_renderer.js
+++ b/audio_renderer.js
@@ -117,7 +117,7 @@ export class AudioRenderer {
     return this.audioContext.suspend();
   }
 
-  getMediaTime(useAudioContextOutputLatency) {
+  getTotalOutputLatencyInSeconds(useAudioContextOutputLatency) {
     let totalOutputLatency = 0.0;
     if (!useAudioContextOutputLatency || this.audioContext.outputLatency == undefined) {
       // Put appropriate values for Chromium here, not sure what latencies are
@@ -128,6 +128,10 @@ export class AudioRenderer {
     }
     // This looks supported by Chromium, always 128 / samplerate.
     totalOutputLatency += this.audioContext.baseLatency;
+    return totalOutputLatency;
+  }
+
+  getMediaTimeInMicroSeconds(totalOutputLatency) {
     // The currently rendered audio sample is the current time of the
     // AudioContext, offset by the total output latency, that is composed of
     // the internal buffering of the AudioContext (e.g., double buffering), and

--- a/simple_video_player.html
+++ b/simple_video_player.html
@@ -22,9 +22,10 @@
   <input id=volume type=range value=0.8 min=0 max=1.0 step=0.01></input>
   Audio buffer health:
   <progress min=0 max=100></progress>
-  Use AudioContext.outputLatency:
+  Total output latency:
+  <span id=totalOutputLatency>N/A</span>
   <input id=outputLatency type=checkbox></input>
-  (Plug Bluetooth headset for best results)
+  Use AudioContext.outputLatency (Connect Bluetooth headset for best results)
 </div>
 <canvas style="outline: 1px solid"></canvas>
 
@@ -45,6 +46,7 @@
 
   await Promise.all([audioReady, videoReady]);
 
+  let totalOutputLatencyElement = $('#totalOutputLatency');
   let isAudioContextOutputLatencySupported = ('outputLatency' in AudioContext.prototype);
   let useAudioContextOutputLatency = isAudioContextOutputLatencySupported;
   $('#outputLatency').disabled = !isAudioContextOutputLatencySupported;
@@ -80,7 +82,9 @@
         if (!playing)
           return;
 
-        videoRenderer.render(audioRenderer.getMediaTime(useAudioContextOutputLatency));
+        let totalOutputLatency = audioRenderer.getTotalOutputLatencyInSeconds(useAudioContextOutputLatency);
+        totalOutputLatencyElement.textContent = `${Math.round(totalOutputLatency * 1000)}ms`;
+        videoRenderer.render(audioRenderer.getMediaTimeInMicroSeconds(totalOutputLatency));
         progressElement.value = audioRenderer.bufferHealth();
         window.requestAnimationFrame(renderVideo);
       });


### PR DESCRIPTION
This PR adds a checkbox so that users can toggle between using `AudioContext.outputLatency` or not to understand the utility of this new attribute coming to the web platform.

FYI @hoch

@chcunningham Please review.